### PR TITLE
Algorithm updates and fixes

### DIFF
--- a/examples/parallel-examples/mnistmlp/runner.py
+++ b/examples/parallel-examples/mnistmlp/runner.py
@@ -43,6 +43,7 @@ def run_example(FLAGS):
                            algorithm=alg,
                            lower_is_better=True,
                            filename='trial.py',
+                           output_dir='output_{}'.format(FLAGS.studyname),
                            scheduler=sched,
                            max_concurrent=FLAGS.max_concurrent)
     print('Best results:')

--- a/examples/parallel-examples/mnistmlp/trial.py
+++ b/examples/parallel-examples/mnistmlp/trial.py
@@ -67,7 +67,7 @@ def main(client, trial):
     model.fit(x_train, y_train,
               batch_size=batch_size,
               epochs=epochs,
-              verbose=1,
+              verbose=2,
               callbacks=[client.keras_send_metrics(trial,
                                                    objective_name='val_loss',
                                                    context_names=['val_acc'])],

--- a/sherpa/algorithms.py
+++ b/sherpa/algorithms.py
@@ -86,7 +86,7 @@ class RandomSearch(Algorithm):
 
     def get_suggestion(self, parameters, results=None, lower_is_better=True):
         # If number of repetitions are reached set them back to zero
-        if self.j > self.m:
+        if self.j == self.m:
             self.j = 0
 
         # If there are no repetitions yet, sample a new config

--- a/sherpa/algorithms.py
+++ b/sherpa/algorithms.py
@@ -79,7 +79,7 @@ class RandomSearch(Algorithm):
     """
     def __init__(self, max_num_trials=None, repeat=1):
         self.i = 0  # number of sampled configs
-        self.n = max_num_trials  # total number of configs to be sampled
+        self.n = max_num_trials or 2**32  # total number of configs to be sampled
         self.m = repeat  # number of times to repeat each config
         self.j = 0  # number of trials submitted with this config
         self.theta_i = {}  # current parameter config

--- a/sherpa/core.py
+++ b/sherpa/core.py
@@ -158,7 +158,7 @@ class Study(object):
         best_idx = (rows['Objective'].idxmin() if self.lower_is_better
                     else rows['Objective'].idxmax())
         try:
-            best_row = rows.ix[best_idx].copy()
+            best_row = rows.loc[best_idx].copy()
         except TypeError:
             warnings.warn("Could not finalize trial {}. Only NaNs "
                           "encountered.".format(trial.id), RuntimeWarning)

--- a/sherpa/database.py
+++ b/sherpa/database.py
@@ -205,6 +205,12 @@ class Client(object):
                   'objective': objective,
                   'iteration': iteration,
                   'context': context}
+        # Convert float32 to float64.
+        # Note: Keras ReduceLROnPlateau callback requires this.
+        for k,v in context.items():
+            if type(v) == numpy.float32:
+                context[k] = numpy.float64(v)
+
         self.db.results.insert_one(result)
 
     def keras_send_metrics(self, trial, objective_name, context_names=[]):

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -138,6 +138,7 @@ def test_Iterate_search():
     assert seen == [(1, 'a', [10]), (1, 'a', [10]),
                     (1, 'b', [10,10]), (2, 'b', {'key':'value'})]
 
+
 def test_grid_search():
     parameters = [sherpa.Choice('a', [1, 2]),
                   sherpa.Choice('b', ['a', 'b']),
@@ -286,3 +287,20 @@ def test_genetic():
         mean_values) > 0.7, "At least 70% of times we add a new result we must improve the average Objective"
 
     results = results[results['Status'] == 'COMPLETED']
+
+
+def test_random_search():
+    parameters = [sherpa.Continuous('a', [0, 1]),
+                  sherpa.Choice('b', ['x', 'y', 'z'])]
+    rs = sherpa.algorithms.RandomSearch(max_num_trials=10, repeat=10)
+    config_repeat = {}
+
+    for i in range(10):
+        config = rs.get_suggestion(parameters=parameters)
+        assert config != config_repeat
+        for j in range(9):
+            config_repeat = rs.get_suggestion(parameters=parameters)
+            assert config == config_repeat
+
+    assert rs.get_suggestion(parameters=parameters) is None
+    

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -303,4 +303,14 @@ def test_random_search():
             assert config == config_repeat
 
     assert rs.get_suggestion(parameters=parameters) is None
+
+    rs = sherpa.algorithms.RandomSearch(max_num_trials=10, repeat=1)
+    last_config = {}
+
+    for i in range(10):
+        config = rs.get_suggestion(parameters=parameters)
+        assert config != last_config
+        last_config = config
+
+    assert rs.get_suggestion(parameters=parameters) is None
     

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -313,4 +313,12 @@ def test_random_search():
         last_config = config
 
     assert rs.get_suggestion(parameters=parameters) is None
-    
+
+
+    rs = sherpa.algorithms.RandomSearch()
+    last_config = {}
+
+    for _ in range(1000):
+        config = rs.get_suggestion(parameters=parameters)
+        assert config != last_config
+        last_config = config


### PR DESCRIPTION
Fixed:

* Local Search: before a new seed would be set with any existing results (i.e. if they are intermediate). Now the seed is only reset once a first completed result exists

Additions:

* Random Search now has a repeat option which repeats the same configuration a given number of times (default is 1 i.e. no repeating). This can be useful to check significance of hyperparameter configurations

Misc:

* Always casting float to a type that MongoDB accepts